### PR TITLE
ci(pr): add basic GPIO functionality

### DIFF
--- a/src/examples/lw_blink
+++ b/src/examples/lw_blink
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2022 Stephan Linz <linz@li-pro.net>
+
+"""
+Simple LED blink at Little Wire pin 1.
+"""
+
+import time
+from sys import stderr, stdout
+
+from verylittlewire import device as vlwd
+
+
+def setLEDAndWait(lw: vlwd.Device, out: int, state: int, ms: int = 500) -> None:
+    lw.digitalWrite(out, state)
+    if ms:
+        time.sleep(ms / 1000)
+
+
+try:
+
+    # attach to the Little Wire
+    lw = vlwd.Device()
+
+    print("----------------------------------------------------------", file=stdout)
+    print(
+        "> Little Wire device found with serialNumber: " + lw.readSerialNumber(),
+        file=stdout,
+    )
+    print("----------------------------------------------------------", file=stdout)
+    print("> Little Wire firmware version: " + lw.readFirmwareVersion(), file=stdout)
+
+    print("----------------------------------------------------------", file=stdout)
+    print("Setup each known pin as input for safty operations.", file=stdout)
+    for pin in [vlwd.PIN1, vlwd.PIN2, vlwd.PIN3, vlwd.PIN4]:
+        lw.pinMode(pin, vlwd.INPUT)
+
+    print("Press ctrl-c to exit.", file=stdout)
+    lw.pinMode(vlwd.PIN1, vlwd.OUTPUT)
+
+    while 1:
+        try:
+            setLEDAndWait(lw, vlwd.PIN1, vlwd.HIGH)
+            setLEDAndWait(lw, vlwd.PIN1, vlwd.LOW)
+
+        except KeyboardInterrupt:
+            setLEDAndWait(lw, vlwd.PIN1, vlwd.LOW, 0)
+            break
+
+except ValueError as ex:
+    print(str(ex), file=stderr)
+
+
+# vim: tw=80 ts=4 sw=4 sts=4 sta et ai nu

--- a/src/examples/lw_blink_loopback
+++ b/src/examples/lw_blink_loopback
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2022 Stephan Linz <linz@li-pro.net>
+
+"""
+Simple LED blink over Little Wire pin 2 with loop back read on pin 1.
+"""
+
+import time
+from sys import stderr, stdout
+
+from verylittlewire import device as vlwd
+
+
+def setLEDVeryfyAndWait(
+    lw: vlwd.Device, out: int, inp: int, state: int, ms: int = 500
+) -> None:
+    lw.digitalWrite(out, state)
+    if lw.digitalRead(inp) != state:
+        print("Loop back fail.", file=stderr)
+    if ms:
+        time.sleep(ms / 1000)
+
+
+try:
+
+    # attach to the Little Wire
+    lw = vlwd.Device()
+
+    print("----------------------------------------------------------", file=stdout)
+    print(
+        "> Little Wire device found with serialNumber: " + lw.readSerialNumber(),
+        file=stdout,
+    )
+    print("----------------------------------------------------------", file=stdout)
+    print("> Little Wire firmware version: " + lw.readFirmwareVersion(), file=stdout)
+
+    print("----------------------------------------------------------", file=stdout)
+    print("Setup each known pin as input for safty operations.", file=stdout)
+    for pin in [vlwd.PIN1, vlwd.PIN2, vlwd.PIN3, vlwd.PIN4]:
+        lw.pinMode(pin, vlwd.INPUT)
+
+    print("Press ctrl-c to exit.", file=stdout)
+    lw.pinMode(vlwd.PIN2, vlwd.OUTPUT)
+    lw.pinMode(vlwd.PIN1, vlwd.INPUT)
+
+    while 1:
+        try:
+            setLEDVeryfyAndWait(lw, vlwd.PIN2, vlwd.PIN1, vlwd.HIGH)
+            setLEDVeryfyAndWait(lw, vlwd.PIN2, vlwd.PIN1, vlwd.LOW)
+
+        except KeyboardInterrupt:
+            setLEDVeryfyAndWait(lw, vlwd.PIN2, vlwd.PIN1, vlwd.LOW, 0)
+            break
+
+except ValueError as ex:
+    print(str(ex), file=stderr)
+
+
+# vim: tw=80 ts=4 sw=4 sts=4 sta et ai nu

--- a/src/examples/lw_button
+++ b/src/examples/lw_button
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2022 Stephan Linz <linz@li-pro.net>
+
+"""
+Simple button press at Little Wire pin 4 with LED feedback on pin 1.
+"""
+
+import time
+from sys import stderr, stdout
+
+from verylittlewire import device as vlwd
+
+
+def getButtonAndDebounce(lw: vlwd.Device, inp: int, state: int, ms: int = 50) -> bool:
+    if lw.digitalRead(inp) == state:
+        time.sleep(ms / 1000)
+
+        if lw.digitalRead(inp) == state:
+            return True
+
+    return False
+
+
+try:
+
+    # attach to the Little Wire
+    lw = vlwd.Device()
+
+    print("----------------------------------------------------------", file=stdout)
+    print(
+        "> Little Wire device found with serialNumber: " + lw.readSerialNumber(),
+        file=stdout,
+    )
+    print("----------------------------------------------------------", file=stdout)
+    print("> Little Wire firmware version: " + lw.readFirmwareVersion(), file=stdout)
+
+    print("----------------------------------------------------------", file=stdout)
+    print("Setup each known pin as input for safty operations.", file=stdout)
+    for pin in [vlwd.PIN1, vlwd.PIN2, vlwd.PIN3, vlwd.PIN4]:
+        lw.pinMode(pin, vlwd.INPUT)
+        lw.internalPullup(pin, vlwd.DISABLE)
+
+    print("Press ctrl-c to exit.", file=stdout)
+    lw.pinMode(vlwd.PIN1, vlwd.OUTPUT)  # feedback is output
+    lw.digitalWrite(vlwd.PIN1, vlwd.LOW)  # feedback LED off
+    lw.pinMode(vlwd.PIN4, vlwd.INPUT)  # button is input
+    lw.internalPullup(vlwd.PIN4, vlwd.ENABLE)  # button preset with pull-up resistor
+
+    buttonPressed = False
+    while 1:
+        try:
+            button = getButtonAndDebounce(lw, vlwd.PIN4, vlwd.LOW)
+            if buttonPressed != button:
+                buttonPressed = button
+
+                if button:
+                    lw.digitalWrite(vlwd.PIN1, vlwd.HIGH)  # feedback LED on
+                    print("Button pressed.")
+
+                else:
+                    lw.digitalWrite(vlwd.PIN1, vlwd.LOW)  # feedback LED off
+                    print("Button released.")
+
+        except KeyboardInterrupt:
+            break
+
+except ValueError as ex:
+    print(str(ex), file=stderr)
+
+
+# vim: tw=80 ts=4 sw=4 sts=4 sta et ai nu

--- a/src/verylittlewire/device.py
+++ b/src/verylittlewire/device.py
@@ -43,6 +43,16 @@ VENDOR_ID = 0x1781
 PRODUCT_ID = 0x0C9F
 USB_TIMEOUT = 5000
 
+# Little Wire pin modes
+INPUT = 1
+OUTPUT = 0
+
+# GPIO pin enumeration
+PIN1 = 1
+PIN2 = 2
+PIN3 = 5
+PIN4 = 0
+
 
 class Device:
     """
@@ -91,6 +101,30 @@ class Device:
         version = result.pop()
 
         return str((version & 0xF0) >> 4) + "." + str(version & 0x0F)
+
+    def pinMode(self, pin: int, mode: int) -> None:
+        """
+        Sets GPIO pins to INPUT(1) or OUTPUT(0).
+        """
+
+        if mode == INPUT:
+            self.lw.ctrl_transfer(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=13,
+                wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
+        else:
+            self.lw.ctrl_transfer(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=14,
+                wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
 
 
 # vim: tw=80 ts=4 sw=4 sts=4 sta et ai nu

--- a/src/verylittlewire/device.py
+++ b/src/verylittlewire/device.py
@@ -43,9 +43,12 @@ VENDOR_ID = 0x1781
 PRODUCT_ID = 0x0C9F
 USB_TIMEOUT = 5000
 
-# Little Wire pin modes
+# Little Wire pin modes and states
 INPUT = 1
 OUTPUT = 0
+
+HIGH = 1
+LOW = 0
 
 # GPIO pin enumeration
 PIN1 = 1
@@ -120,6 +123,30 @@ class Device:
             self.lw.ctrl_transfer(  # type: ignore[union-attr]
                 bmRequestType=0xC0,
                 bRequest=14,
+                wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
+
+    def digitalWrite(self, pin: int, state: int) -> None:
+        """
+        Writes a digital HIGH (1) or LOW (0) to the selected GPIO.
+        """
+
+        if state == HIGH:
+            self.lw.ctrl_transfer(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=18,
+                wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
+        else:
+            self.lw.ctrl_transfer(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=19,
                 wValue=pin,
                 wIndex=0,
                 data_or_wLength=8,

--- a/src/verylittlewire/device.py
+++ b/src/verylittlewire/device.py
@@ -50,6 +50,10 @@ OUTPUT = 0
 HIGH = 1
 LOW = 0
 
+# Little Wire internal pull-up resistor states
+ENABLE = 1
+DISABLE = 0
+
 # GPIO pin enumeration
 PIN1 = 1
 PIN2 = 2
@@ -170,6 +174,13 @@ class Device:
         status = result.pop()
 
         return int(status)
+
+    def internalPullup(self, pin: int, state: int) -> None:
+        """
+        Sets the state of the internal pull-up resistor for the selected GPIO.
+        """
+
+        self.digitalWrite(pin, state)
 
 
 # vim: tw=80 ts=4 sw=4 sts=4 sta et ai nu

--- a/src/verylittlewire/device.py
+++ b/src/verylittlewire/device.py
@@ -153,5 +153,23 @@ class Device:
                 timeout=USB_TIMEOUT,
             )
 
+    def digitalRead(self, pin: int) -> int:
+        """
+        Returns the digital status of the selected GPIO
+        """
+
+        result = self.lw.ctrl_transfer(  # type: ignore[union-attr]
+            bmRequestType=0xC0,
+            bRequest=20,
+            wValue=pin,
+            wIndex=0,
+            data_or_wLength=8,
+            timeout=USB_TIMEOUT,
+        )
+
+        status = result.pop()
+
+        return int(status)
+
 
 # vim: tw=80 ts=4 sw=4 sts=4 sta et ai nu

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -29,6 +29,14 @@ VENDOR_ID = 0x1781
 PRODUCT_ID = 0x0C9F
 USB_TIMEOUT = 5000
 
+INPUT = 1
+OUTPUT = 0
+
+PIN1 = 1
+PIN2 = 2
+PIN3 = 5
+PIN4 = 0
+
 
 class Device(unittest.TestCase):
     def test_usb_vendor(self):
@@ -113,6 +121,78 @@ class Device(unittest.TestCase):
             data_or_wLength=8,
             timeout=USB_TIMEOUT,
         )
+
+    def test_pin_modes(self):
+        """
+        UNIT TEST: provide all expected PIN modes
+        """
+
+        self.assertEqual(vlwd.INPUT, INPUT)
+        self.assertEqual(vlwd.OUTPUT, OUTPUT)
+
+    def test_pin_names(self):
+        """
+        UNIT TEST: provide all expected PIN names
+        """
+
+        self.assertEqual(vlwd.PIN1, PIN1)
+        self.assertEqual(vlwd.PIN2, PIN2)
+        self.assertEqual(vlwd.PIN3, PIN3)
+        self.assertEqual(vlwd.PIN4, PIN4)
+
+    @mock.patch.object(vlwd.Device, "lw")
+    @mock.patch("verylittlewire.device.usb")
+    def test_pin_mode_input(self, mock_usb, mock_lw):
+        """
+        UNIT TEST: setup each known pin as input
+        """
+
+        device = vlwd.Device()
+        self.assertIsNotNone(device)
+        self.assertIsNotNone(device.lw)
+        self.assertIsInstance(device, vlwd.Device)
+
+        for pin in [vlwd.PIN1, vlwd.PIN2, vlwd.PIN3, vlwd.PIN4]:
+
+            result = device.pinMode(pin, vlwd.INPUT)  # type: ignore[func-returns-value]
+            self.assertIsNone(result)
+
+            device.lw.ctrl_transfer.assert_called_with(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=13,
+                wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
+
+    @mock.patch.object(vlwd.Device, "lw")
+    @mock.patch("verylittlewire.device.usb")
+    def test_pin_mode_output(self, mock_usb, mock_lw):
+        """
+        UNIT TEST: setup each known pin as output
+        """
+
+        device = vlwd.Device()
+        self.assertIsNotNone(device)
+        self.assertIsNotNone(device.lw)
+        self.assertIsInstance(device, vlwd.Device)
+
+        for pin in [vlwd.PIN1, vlwd.PIN2, vlwd.PIN3, vlwd.PIN4]:
+
+            result = device.pinMode(  # type: ignore[func-returns-value]
+                pin, vlwd.OUTPUT
+            )
+            self.assertIsNone(result)
+
+            device.lw.ctrl_transfer.assert_called_with(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=14,
+                wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
 
 
 # vim: tw=80 ts=4 sw=4 sts=4 sta et ai nu

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -32,6 +32,9 @@ USB_TIMEOUT = 5000
 INPUT = 1
 OUTPUT = 0
 
+HIGH = 1
+LOW = 0
+
 PIN1 = 1
 PIN2 = 2
 PIN3 = 5
@@ -130,6 +133,14 @@ class Device(unittest.TestCase):
         self.assertEqual(vlwd.INPUT, INPUT)
         self.assertEqual(vlwd.OUTPUT, OUTPUT)
 
+    def test_pin_states(self):
+        """
+        UNIT TEST: provide all expected PIN states
+        """
+
+        self.assertEqual(vlwd.HIGH, HIGH)
+        self.assertEqual(vlwd.LOW, LOW)
+
     def test_pin_names(self):
         """
         UNIT TEST: provide all expected PIN names
@@ -188,6 +199,62 @@ class Device(unittest.TestCase):
             device.lw.ctrl_transfer.assert_called_with(  # type: ignore[union-attr]
                 bmRequestType=0xC0,
                 bRequest=14,
+                wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
+
+    @mock.patch.object(vlwd.Device, "lw")
+    @mock.patch("verylittlewire.device.usb")
+    def test_digital_write_high(self, mock_usb, mock_lw):
+        """
+        UNIT TEST: write out digital high to each known pin
+        """
+
+        device = vlwd.Device()
+        self.assertIsNotNone(device)
+        self.assertIsNotNone(device.lw)
+        self.assertIsInstance(device, vlwd.Device)
+
+        for pin in [vlwd.PIN1, vlwd.PIN2, vlwd.PIN3, vlwd.PIN4]:
+
+            result = device.digitalWrite(  # type: ignore[func-returns-value]
+                pin, vlwd.HIGH
+            )
+            self.assertIsNone(result)
+
+            device.lw.ctrl_transfer.assert_called_with(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=18,
+                wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
+
+    @mock.patch.object(vlwd.Device, "lw")
+    @mock.patch("verylittlewire.device.usb")
+    def test_digital_write_low(self, mock_usb, mock_lw):
+        """
+        UNIT TEST: write out digital low to each known pin
+        """
+
+        device = vlwd.Device()
+        self.assertIsNotNone(device)
+        self.assertIsNotNone(device.lw)
+        self.assertIsInstance(device, vlwd.Device)
+
+        for pin in [vlwd.PIN1, vlwd.PIN2, vlwd.PIN3, vlwd.PIN4]:
+
+            result = device.digitalWrite(  # type: ignore[func-returns-value]
+                pin, vlwd.LOW
+            )
+            self.assertIsNone(result)
+
+            device.lw.ctrl_transfer.assert_called_with(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=19,
                 wValue=pin,
                 wIndex=0,
                 data_or_wLength=8,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -35,6 +35,9 @@ OUTPUT = 0
 HIGH = 1
 LOW = 0
 
+ENABLE = 1
+DISABLE = 0
+
 PIN1 = 1
 PIN2 = 2
 PIN3 = 5
@@ -282,6 +285,70 @@ class Device(unittest.TestCase):
             device.lw.ctrl_transfer.assert_called_with(  # type: ignore[union-attr]
                 bmRequestType=0xC0,
                 bRequest=20,
+                wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
+
+    def test_pullup_states(self):
+        """
+        UNIT TEST: provide all expected pull-up resistor states
+        """
+
+        self.assertEqual(vlwd.ENABLE, ENABLE)
+        self.assertEqual(vlwd.DISABLE, DISABLE)
+
+    @mock.patch.object(vlwd.Device, "lw")
+    @mock.patch("verylittlewire.device.usb")
+    def test_pullup_enable(self, mock_usb, mock_lw):
+        """
+        UNIT TEST: enable pull-up resistor on each known pin
+        """
+
+        device = vlwd.Device()
+        self.assertIsNotNone(device)
+        self.assertIsNotNone(device.lw)
+        self.assertIsInstance(device, vlwd.Device)
+
+        for pin in [vlwd.PIN1, vlwd.PIN2, vlwd.PIN3, vlwd.PIN4]:
+
+            result = device.internalPullup(  # type: ignore[func-returns-value]
+                pin, vlwd.ENABLE
+            )
+            self.assertIsNone(result)
+
+            device.lw.ctrl_transfer.assert_called_with(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=18,
+                wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
+
+    @mock.patch.object(vlwd.Device, "lw")
+    @mock.patch("verylittlewire.device.usb")
+    def test_pullup_disable(self, mock_usb, mock_lw):
+        """
+        UNIT TEST: disable pull-up resistor on each known pin
+        """
+
+        device = vlwd.Device()
+        self.assertIsNotNone(device)
+        self.assertIsNotNone(device.lw)
+        self.assertIsInstance(device, vlwd.Device)
+
+        for pin in [vlwd.PIN1, vlwd.PIN2, vlwd.PIN3, vlwd.PIN4]:
+
+            result = device.internalPullup(  # type: ignore[func-returns-value]
+                pin, vlwd.DISABLE
+            )
+            self.assertIsNone(result)
+
+            device.lw.ctrl_transfer.assert_called_with(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=19,
                 wValue=pin,
                 wIndex=0,
                 data_or_wLength=8,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -261,5 +261,32 @@ class Device(unittest.TestCase):
                 timeout=USB_TIMEOUT,
             )
 
+    @mock.patch.object(vlwd.Device, "lw")
+    @mock.patch("verylittlewire.device.usb")
+    def test_digital_read_state(self, mock_usb, mock_lw):
+        """
+        UNIT TEST: read in current digital status from each known pin
+        """
+
+        device = vlwd.Device()
+        self.assertIsNotNone(device)
+        self.assertIsNotNone(device.lw)
+        self.assertIsInstance(device, vlwd.Device)
+
+        for pin in [vlwd.PIN1, vlwd.PIN2, vlwd.PIN3, vlwd.PIN4]:
+
+            status = device.digitalRead(pin)
+            self.assertIsNotNone(status)
+            self.assertIsInstance(status, int)
+
+            device.lw.ctrl_transfer.assert_called_with(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=20,
+                wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
+
 
 # vim: tw=80 ts=4 sw=4 sts=4 sta et ai nu


### PR DESCRIPTION
- Little Wire PIN mode setup (in or out direction)
- Little Wire PIN state read (general purpose input
  of current logical level on dedicated PIN)
- Little Wire PIN state write (general purpose output
  of an logical level on dedicated PIN)

related to: #2