### PR TITLE
ci(pr): add basic ADC functionality

### DIFF
--- a/src/examples/lw_adc
+++ b/src/examples/lw_adc
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2022 Stephan Linz <linz@li-pro.net>
+
+# NOTE: you need `pip3 install ascii_graph`
+
+"""
+Simple ADC voltage level at Little Wire pin 2 (channel 1).
+"""
+
+from sys import stderr, stdout
+
+from ascii_graph import Pyasciigraph
+
+from verylittlewire import device as vlwd
+
+try:
+
+    # attach to the Little Wire
+    lw = vlwd.Device()
+
+    print("----------------------------------------------------------", file=stdout)
+    print(
+        "> Little Wire device found with serialNumber: " + lw.readSerialNumber(),
+        file=stdout,
+    )
+    print("----------------------------------------------------------", file=stdout)
+    print("> Little Wire firmware version: " + lw.readFirmwareVersion(), file=stdout)
+
+    print("----------------------------------------------------------", file=stdout)
+    print("Setup each known pin as input for safty operations.", file=stdout)
+    for pin in [vlwd.PIN1, vlwd.PIN2, vlwd.PIN3, vlwd.PIN4]:
+        lw.pinMode(pin, vlwd.INPUT)
+
+    print("Press ctrl-c to exit.", file=stdout)
+    lw.analogInit(vlwd.VREF_VCC)
+
+    graph = Pyasciigraph()
+
+    while 1:
+        try:
+            levels = [
+                (
+                    "mV @ ADC_PIN3 (ADC0)",
+                    (lw.analogRead(vlwd.ADC_PIN3) * (5000.0)) / 1024.0,
+                ),
+                (
+                    "mV @ ADC_PIN2 (ADC1)",
+                    (lw.analogRead(vlwd.ADC_PIN2) * (5000.0)) / 1024.0,
+                ),
+            ]
+            for level in graph.graph("Voltage level:", levels):
+                print(level, file=stdout)
+
+        except KeyboardInterrupt:
+            break
+
+except ValueError as ex:
+    print(str(ex), file=stderr)
+
+
+# vim: tw=80 ts=4 sw=4 sts=4 sta et ai nu

--- a/src/verylittlewire/device.py
+++ b/src/verylittlewire/device.py
@@ -65,6 +65,16 @@ VREF_VCC = 0
 VREF_1100mV = 1
 VREF_2560mV = 2
 
+# ADC channel enumeration
+ADC_PIN3 = 0
+ADC_PIN2 = 1
+ADC_TEMP_SENS = 2
+
+# ADC channel aliases
+ADC0 = ADC_PIN3
+ADC1 = ADC_PIN2
+ADC2 = ADC_TEMP_SENS
+
 
 class Device:
     """
@@ -200,6 +210,24 @@ class Device:
             data_or_wLength=8,
             timeout=USB_TIMEOUT,
         )
+
+    def analogRead(self, channel: int) -> int:
+        """
+        Sets voltage reference level for all ADC channel.
+        """
+
+        result = self.lw.ctrl_transfer(  # type: ignore[union-attr]
+            bmRequestType=0xC0,
+            bRequest=15,
+            wValue=channel,
+            wIndex=0,
+            data_or_wLength=8,
+            timeout=USB_TIMEOUT,
+        )
+
+        level = (result.pop() * 256) + result.pop()
+
+        return int(level)
 
 
 # vim: tw=80 ts=4 sw=4 sts=4 sta et ai nu

--- a/src/verylittlewire/device.py
+++ b/src/verylittlewire/device.py
@@ -60,6 +60,11 @@ PIN2 = 2
 PIN3 = 5
 PIN4 = 0
 
+# ADC voltage reference level
+VREF_VCC = 0
+VREF_1100mV = 1
+VREF_2560mV = 2
+
 
 class Device:
     """
@@ -181,6 +186,20 @@ class Device:
         """
 
         self.digitalWrite(pin, state)
+
+    def analogInit(self, vref: int) -> None:
+        """
+        Sets voltage reference level for all ADC channel.
+        """
+
+        self.lw.ctrl_transfer(  # type: ignore[union-attr]
+            bmRequestType=0xC0,
+            bRequest=35,
+            wValue=((vref << 8) | 0x07),
+            wIndex=0,
+            data_or_wLength=8,
+            timeout=USB_TIMEOUT,
+        )
 
 
 # vim: tw=80 ts=4 sw=4 sts=4 sta et ai nu

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -43,6 +43,10 @@ PIN2 = 2
 PIN3 = 5
 PIN4 = 0
 
+VREF_VCC = 0
+VREF_1100mV = 1
+VREF_2560mV = 2
+
 
 class Device(unittest.TestCase):
     def test_usb_vendor(self):
@@ -350,6 +354,41 @@ class Device(unittest.TestCase):
                 bmRequestType=0xC0,
                 bRequest=19,
                 wValue=pin,
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
+
+    def test_analog_vref_levels(self):
+        """
+        UNIT TEST: provide all expected analog voltage reference levels
+        """
+
+        self.assertEqual(vlwd.VREF_VCC, VREF_VCC)
+        self.assertEqual(vlwd.VREF_1100mV, VREF_1100mV)
+        self.assertEqual(vlwd.VREF_2560mV, VREF_2560mV)
+
+    @mock.patch.object(vlwd.Device, "lw")
+    @mock.patch("verylittlewire.device.usb")
+    def test_analog_init_levels(self, mock_usb, mock_lw):
+        """
+        UNIT TEST: setup ADC with each known voltage reference level
+        """
+
+        device = vlwd.Device()
+        self.assertIsNotNone(device)
+        self.assertIsNotNone(device.lw)
+        self.assertIsInstance(device, vlwd.Device)
+
+        for vref in [vlwd.VREF_VCC, vlwd.VREF_1100mV, vlwd.VREF_2560mV]:
+
+            result = device.analogInit(vref)  # type: ignore[func-returns-value]
+            self.assertIsNone(result)
+
+            device.lw.ctrl_transfer.assert_called_with(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=35,
+                wValue=((vref << 8) | 0x07),
                 wIndex=0,
                 data_or_wLength=8,
                 timeout=USB_TIMEOUT,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -47,6 +47,10 @@ VREF_VCC = 0
 VREF_1100mV = 1
 VREF_2560mV = 2
 
+ADC_PIN3 = 0
+ADC_PIN2 = 1
+ADC_TEMP_SENS = 2
+
 
 class Device(unittest.TestCase):
     def test_usb_vendor(self):
@@ -389,6 +393,58 @@ class Device(unittest.TestCase):
                 bmRequestType=0xC0,
                 bRequest=35,
                 wValue=((vref << 8) | 0x07),
+                wIndex=0,
+                data_or_wLength=8,
+                timeout=USB_TIMEOUT,
+            )
+
+    def test_analog_channel_names(self):
+        """
+        UNIT TEST: provide all expected analog channel names
+        """
+
+        self.assertEqual(vlwd.ADC_PIN3, ADC_PIN3)
+        self.assertEqual(vlwd.ADC_PIN2, ADC_PIN2)
+        self.assertEqual(vlwd.ADC_TEMP_SENS, ADC_TEMP_SENS)
+
+    def test_analog_channel_aliases(self):
+        """
+        UNIT TEST: provide all expected analog channel aliases
+        """
+
+        self.assertEqual(vlwd.ADC0, ADC_PIN3)
+        self.assertEqual(vlwd.ADC1, ADC_PIN2)
+        self.assertEqual(vlwd.ADC2, ADC_TEMP_SENS)
+
+    @mock.patch.object(vlwd.Device, "lw")
+    @mock.patch("verylittlewire.device.usb")
+    def test_analog_read_level(self, mock_usb, mock_lw):
+        """
+        UNIT TEST: read in current analog level from each known channel
+        """
+
+        device = vlwd.Device()
+        self.assertIsNotNone(device)
+        self.assertIsNotNone(device.lw)
+        self.assertIsInstance(device, vlwd.Device)
+
+        for channel in [
+            vlwd.ADC_PIN3,
+            vlwd.ADC0,
+            vlwd.ADC_PIN2,
+            vlwd.ADC1,
+            vlwd.ADC_TEMP_SENS,
+            vlwd.ADC2,
+        ]:
+
+            level = device.analogRead(channel)
+            self.assertIsNotNone(level)
+            self.assertIsInstance(level, int)
+
+            device.lw.ctrl_transfer.assert_called_with(  # type: ignore[union-attr]
+                bmRequestType=0xC0,
+                bRequest=15,
+                wValue=channel,
                 wIndex=0,
                 data_or_wLength=8,
                 timeout=USB_TIMEOUT,


### PR DESCRIPTION
- Little Wire ADC reference voltage value setup
  (new in firmware 1.1)
- Little Wire ADC 10 bit quantized value read as two byte
  (new in firmware 1.1)

related to: #3